### PR TITLE
Change app name for the dev app

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -6,7 +6,7 @@
     "distDir": "../dist"
   },
   "package": {
-    "productName": "Keeper Desktop",
+    "productName": "Keeper Desktop (Dev)",
     "version": "0.1.3"
   },
   "tauri": {
@@ -27,7 +27,7 @@
     },
     "windows": [
       {
-        "title": "Keeper Desktop",
+        "title": "Keeper Desktop (Dev)",
         "width": 900,
         "height": 670,
         "resizable": false,

--- a/src-tauri/tauri.release.conf.json
+++ b/src-tauri/tauri.release.conf.json
@@ -1,4 +1,14 @@
 {
+  "package": {
+    "productName": "Keeper Desktop"
+  },
+  "tauri": {
+    "windows": [
+      {
+        "title": "Keeper Desktop"
+      }
+    ]
+  },
   "build": {
     "features": ["release"]
   }


### PR DESCRIPTION
Change app name for the dev app to avoid overlap with prod app.